### PR TITLE
Refactor

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
-# Specify your gem's dependencies in storage_proxy_client.gemspec
+# Specify your gem's dependencies in storage_proxy_api.gemspec
 gemspec

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # StorageProxyAPI
 
-This gem provides a Ruby interface to the Camel-based [External Storage Proxy](https://github.com/samvera-labs/samvera-external_storage).
+This gem provides a Ruby interface to the Camel-based [External Storage Proxy](https://github.com/samvera-labs/samvera-external_storage), which is a tool to provide a common interface between Hyrax applications and multiple 3rd party storage services.
 
 ## Installation
 
@@ -20,4 +20,29 @@ Or install it yourself as:
 
 ## Usage
 
+Instantiate a `StorageProxyAPI::Client` to make API calls to the storage proxy.
 
+```ruby
+require 'storage_proxy_api/client'
+base_url = 'http://localhost:9091' # replace this value with wherever the storage proxy is listening for requests.
+client = StorageProxyAPI::Client.new(base_url: base_url)
+```
+
+Send a request to get the status of a file and see if it is currently staged.
+
+```ruby
+# The :service option is used to tell the External Storage Proxy which algorithm to use when translating
+# an incoming request into the request that is forwarded on to the 3rd party storage service.
+# The :external_uri option is the URI by which files are identified in the 3rd party storage service.
+# TODO: Replace :service and :external_uri options with a real world example when we have one.
+# The possible values for :service option should come from the External Storage Proxy.
+response = client.status(service: "Example Storage Service", external_uri: "foo:bar")
+response.staged? # returns true or false
+```
+
+Send a request to stage a file.
+
+```ruby
+response = client.stage(service: "Example Storage Service", external_uri: "foo:bar")
+response.staged_location # returns a URI that can be used to download the file.
+```

--- a/README.md
+++ b/README.md
@@ -1,15 +1,13 @@
-# StorageProxyClient
+# StorageProxyAPI
 
-Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/storage_proxy_client`. To experiment with that code, run `bin/console` for an interactive prompt.
-
-TODO: Delete this and the text above, and describe your gem
+This gem provides a Ruby interface to the Camel-based [External Storage Proxy](https://github.com/samvera-labs/samvera-external_storage).
 
 ## Installation
 
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'storage_proxy_client'
+gem 'storage_proxy_api'
 ```
 
 And then execute:
@@ -18,19 +16,8 @@ And then execute:
 
 Or install it yourself as:
 
-    $ gem install storage_proxy_client
+    $ gem install storage_proxy_api
 
 ## Usage
 
-TODO: Write usage instructions here
-
-## Development
-
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
-
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
-
-## Contributing
-
-Bug reports and pull requests are welcome on GitHub at https://github.com/Andrew Myers/storage_proxy_client.
 

--- a/bin/console
+++ b/bin/console
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 require "bundler/setup"
-require "storage_proxy_client"
+require "storage_proxy_api"
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.

--- a/lib/storage_proxy_api.rb
+++ b/lib/storage_proxy_api.rb
@@ -1,0 +1,4 @@
+require "storage_proxy_api/version"
+
+module StorageProxyAPI
+end

--- a/lib/storage_proxy_api/client.rb
+++ b/lib/storage_proxy_api/client.rb
@@ -31,11 +31,22 @@ module StorageProxyAPI
     end
 
     def status(service:, external_uri:, include_events: false)
-      send_request(http_method: :get, action: 'status', headers: { service: service, include_events: include_events }, params: { external_uri: external_uri} )
+      send_request(http_method: :get, action: 'status', headers: { service: service, include_events: boolean_string(include_events) }, params: { external_uri: external_uri} )
     end
 
     def stage(service:, external_uri:)
       send_request(http_method: :post, action: 'stage', headers: { service: service }, params: { external_uri: external_uri } )
     end
+
+    private
+
+      def boolean_string(value)
+        case value
+        when nil, 0, '0', '', false, 'false'
+          '0'
+        else
+          '1'
+        end
+      end
   end
 end

--- a/lib/storage_proxy_api/client.rb
+++ b/lib/storage_proxy_api/client.rb
@@ -1,8 +1,8 @@
 require 'faraday'
-require 'storage_proxy_client/response'
+require 'storage_proxy_api/response'
 
 
-module StorageProxyClient
+module StorageProxyAPI
   class Client
     attr_reader :base_url
 
@@ -23,7 +23,7 @@ module StorageProxyClient
         faraday_request.body = body if body
       end
 
-      StorageProxyClient::Response.new(
+      StorageProxyAPI::Response.new(
         status: faraday_response.status,
         body: faraday_response.body,
         headers: faraday_response.headers

--- a/lib/storage_proxy_api/client.rb
+++ b/lib/storage_proxy_api/client.rb
@@ -31,11 +31,11 @@ module StorageProxyAPI
     end
 
     def status(service:, external_uri:, include_events: false)
-      send_request(:get, action: 'status', headers: { service: service, include_events: include_events }, params: { external_uri: external_uri} )
+      send_request(http_method: :get, action: 'status', headers: { service: service, include_events: include_events }, params: { external_uri: external_uri} )
     end
 
     def stage(service:, external_uri:)
-      send_request(:post, action: 'stage', headers: { service: service }, params: { external_uri: external_uri } )
+      send_request(http_method: :post, action: 'stage', headers: { service: service }, params: { external_uri: external_uri } )
     end
   end
 end

--- a/lib/storage_proxy_api/response.rb
+++ b/lib/storage_proxy_api/response.rb
@@ -18,7 +18,7 @@ module StorageProxyAPI
 
     def staging?
       # FIXME There is no staging field yet in the api spec.
-      parsed_body['staging'] == '1'
+      body['staging'] == '1'
     end
 
     def staged_location

--- a/lib/storage_proxy_api/response.rb
+++ b/lib/storage_proxy_api/response.rb
@@ -1,7 +1,7 @@
-require 'storage_proxy_client'
+require 'storage_proxy_api'
 require 'json'
 
-module StorageProxyClient
+module StorageProxyAPI
   class Response
     attr_accessor :status, :body, :headers
 

--- a/lib/storage_proxy_api/version.rb
+++ b/lib/storage_proxy_api/version.rb
@@ -1,0 +1,3 @@
+module StorageProxyAPI
+  VERSION = "0.1.0"
+end

--- a/lib/storage_proxy_client.rb
+++ b/lib/storage_proxy_client.rb
@@ -1,4 +1,0 @@
-require "storage_proxy_client/version"
-
-module StorageProxyClient
-end

--- a/lib/storage_proxy_client/response.rb
+++ b/lib/storage_proxy_client/response.rb
@@ -3,14 +3,17 @@ require 'json'
 
 module StorageProxyClient
   class Response
-    attr_accessor :faraday_response, :parsed_body
+    attr_accessor :status, :body, :headers
 
-    def initialize(faraday_response: nil)
-      @faraday_response = faraday_response
+    def initialize(status: nil, body: nil, headers: nil)
+      @status = status
+      @headers = headers
+      # Assume the body is JSON.
+      @body = JSON.parse body unless body.empty?
     end
 
     def staged?
-      parsed_body['staged'] == '1'
+      body['staged'] == '1'
     end
 
     def staging?
@@ -19,13 +22,7 @@ module StorageProxyClient
     end
 
     def staged_location
-      parsed_body['staged_location']
+      body['staged_location']
     end
-
-    private
-
-      def parsed_body
-        @parsed_body ||= JSON.parse faraday_response.body
-      end
   end
 end

--- a/lib/storage_proxy_client/version.rb
+++ b/lib/storage_proxy_client/version.rb
@@ -1,3 +1,0 @@
-module StorageProxyClient
-  VERSION = "0.1.0"
-end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
 require "bundler/setup"
-require "storage_proxy_client"
+require "storage_proxy_api"
 require 'webmock/rspec'
 WebMock.disable_net_connect!
 

--- a/spec/storage_proxy_api/client_spec.rb
+++ b/spec/storage_proxy_api/client_spec.rb
@@ -52,23 +52,34 @@ describe StorageProxyAPI::Client do
     end
   end
 
+
   describe '#status' do
-    let(:service) { "fake_service" }
-    let(:include_events) { true }
-    let(:external_uri) { "fake_uri" }
+    let(:headers) { { service: 'fake service', include_events: 'true' } }
+    let(:params) { { external_uri: 'fake_uri' } }
+
+    before do
+      stub_request(:get, "#{subject.base_url}/status").
+        with(headers: headers, query: params)
+    end
+
     it 'calls #send_request with http_method: :get, action: "status", passes :inclue_events and :service as headers, and :external_uri as a param' do
-      expect(subject).to receive(:send_request).with(:get, action: "status", headers: { service: service, include_events: include_events }, params: { external_uri: external_uri } )
-      subject.status(service: service, include_events: include_events, external_uri: external_uri)
+      expect(subject).to receive(:send_request).with(http_method: :get, action: "status", headers: headers, params: params ).and_call_original
+      subject.status(service: headers[:service], include_events: headers[:include_events], external_uri: params[:external_uri])
     end
   end
 
   describe '#stage' do
-    let(:service) { "fake_service" }
-    let(:include_events) { true }
-    let(:external_uri) { "fake_uri" }
+    let(:headers) { { service: 'fake service' } }
+    let(:params) { { external_uri: 'fake_uri' } }
+
+    before do
+      stub_request(:post, "#{subject.base_url}/stage").
+        with(headers: headers, query: params)
+    end
+
     it 'calls #send_request with http_method: :post, action: "stage", passes :inclue_events and :service as headers, and :external_uri as a param' do
-      expect(subject).to receive(:send_request).with(:post, action: "stage", headers: { service: service }, params: { external_uri: external_uri } )
-      subject.stage(service: service, external_uri: external_uri)
+      expect(subject).to receive(:send_request).with(http_method: :post, action: "stage", headers: headers, params: params ).and_call_original
+      subject.stage(service: headers[:service], external_uri: params[:external_uri])
     end
   end
 end

--- a/spec/storage_proxy_api/client_spec.rb
+++ b/spec/storage_proxy_api/client_spec.rb
@@ -54,7 +54,7 @@ describe StorageProxyAPI::Client do
 
 
   describe '#status' do
-    let(:headers) { { service: 'fake service', include_events: 'true' } }
+    let(:headers) { { service: 'fake service', include_events: '1' } }
     let(:params) { { external_uri: 'fake_uri' } }
 
     before do

--- a/spec/storage_proxy_api/client_spec.rb
+++ b/spec/storage_proxy_api/client_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
-require 'storage_proxy_client/client'
+require 'storage_proxy_api/client'
 
-describe StorageProxyClient::Client do
+describe StorageProxyAPI::Client do
 
   subject { described_class.new(base_url: 'http://mock-storage-proxy-host.org:1234') }
   let(:example_service) { "Example Service" }
@@ -38,7 +38,7 @@ describe StorageProxyClient::Client do
 
         it 'passes them along to the request' do
           expect(subject.conn).to receive(:get).and_call_original
-          expect(StorageProxyClient::Response).to receive(:new).with(status: 200, headers: response_headers, body: response_body)
+          expect(StorageProxyAPI::Response).to receive(:new).with(status: 200, headers: response_headers, body: response_body)
           subject.send_request(http_method: :get, action: action, headers: request_headers, params: request_params, body: request_body)
         end
       end

--- a/spec/storage_proxy_api/response_spec.rb
+++ b/spec/storage_proxy_api/response_spec.rb
@@ -1,12 +1,10 @@
 require 'spec_helper'
 
-describe StorageProxyClient::Response do
+describe StorageProxyAPI::Response do
+  let(:mock_external_uri) { 'http://some_service.org' }
+  let(:mock_vendor_service) { 'fake vendor' }
 
-  let(:body) { { foo: "bar"}.to_json }
-
-  context 'when the body is a JSON string'
-
-  subject { described_class.new(body: body) }
+  subject { described_class.new(body: mock_response_body.to_json) }
 
   describe 'staged?' do
     context 'when the response reports that the file is staged' do

--- a/spec/storage_proxy_api_spec.rb
+++ b/spec/storage_proxy_api_spec.rb
@@ -1,0 +1,7 @@
+require "spec_helper"
+
+RSpec.describe StorageProxyAPI do
+  it "has a version number" do
+    expect(StorageProxyAPI::VERSION).not_to be nil
+  end
+end

--- a/spec/storage_proxy_client/client_spec.rb
+++ b/spec/storage_proxy_client/client_spec.rb
@@ -3,73 +3,72 @@ require 'storage_proxy_client/client'
 
 describe StorageProxyClient::Client do
 
-  let(:external_uri) { ['example_host:12234', 'http://example.org/12355'].sample }
-  let(:fake_service) { "Example Service" }
-
-  subject { described_class.new(external_uri: external_uri, service: fake_service) }
+  subject { described_class.new(base_url: 'http://mock-storage-proxy-host.org:1234') }
+  let(:example_service) { "Example Service" }
+  let(:example_external_uri) { ['example_filename.dat', 's3://example_bucket/exmple_file.dat'].sample }
 
   before do
-    stub_request(:get, "http://localhost:9091/status?external_uri=#{CGI.escape(external_uri)}").
-      to_return(status: expected_resp_status, body: expected_resp_body, headers: expected_resp_headers)
+    # Stub base_uri for both GET and POST requests
+    stub_request(:get, "#{subject.base_url}")
+    stub_request(:post, "#{subject.base_url}")
   end
 
-  # Set defaults for the values used in the mocked request
-  let(:endpoint) { Regexp.new('.*') }
-  let(:expected_req_headers) { { } }
-  let(:expected_resp_headers) { { } }
-  let(:expected_resp_body) { '' }
-  let(:expected_resp_status) { '500' }
+  describe '#send_request' do
+    context 'when :http_method is :get' do
+      it 'sends a GET request' do
+        expect(subject.conn).to receive(:get).and_call_original
+        subject.send_request(http_method: :get)
+      end
 
+      context 'when given headers, params, and a body' do
+        let(:action) { 'astley' }
+
+        let(:request_headers) { { rickroll: "1" } }
+        let(:request_params) { { give_you_up: "let you down" } }
+        let(:request_body) { { run_around: "desert you" }.to_json }
+
+        let(:response_headers) { { make_you_cry: "say goodbye" } }
+        let(:response_body) { { tell_a_lie: "hurt you" }.to_json }
+
+        before do
+          stub_request(:get, "#{subject.base_url}/#{action}").
+            with(headers: request_headers, query: request_params, body: request_body).
+            to_return(status: 200, headers: response_headers, body: response_body)
+        end
+
+        it 'passes them along to the request' do
+          expect(subject.conn).to receive(:get).and_call_original
+          expect(StorageProxyClient::Response).to receive(:new).with(status: 200, headers: response_headers, body: response_body)
+          subject.send_request(http_method: :get, action: action, headers: request_headers, params: request_params, body: request_body)
+        end
+      end
+    end
+
+    context 'when :http_method is :post' do
+      it 'sends a POST request' do
+        expect(subject.conn).to receive(:post).and_call_original
+        subject.send_request(http_method: :post)
+      end
+    end
+  end
 
   describe '#status' do
-    it 'returns a StorageProxyClient::Response object' do
-      expect(subject.status).to be_a StorageProxyClient::Response
-    end
-
-    it 'sends a request to the "status" API endpoint with the correct headers' do
-      status_uri = subject.send(:build_request_uri, :status)
-      status_headers = subject.send(:build_request_headers)
-      expect(subject.conn).to receive(:get).with(status_uri, nil, status_headers)
-      expect(subject.status)
+    let(:service) { "fake_service" }
+    let(:include_events) { true }
+    let(:external_uri) { "fake_uri" }
+    it 'calls #send_request with http_method: :get, action: "status", passes :inclue_events and :service as headers, and :external_uri as a param' do
+      expect(subject).to receive(:send_request).with(:get, action: "status", headers: { service: service, include_events: include_events }, params: { external_uri: external_uri } )
+      subject.status(service: service, include_events: include_events, external_uri: external_uri)
     end
   end
 
-  describe '#stage'  do
-    it 'returns a StorageProxyClient::Response object' do
-      expect(subject.status).to be_a StorageProxyClient::Response
-    end
-
-    it 'sends a request to the "stage" API endpoint with the correct headers' do
-      stage_uri = subject.send(:build_request_uri, :stage)
-      stage_headers = subject.send(:build_request_headers)
-      expect(subject.conn).to receive(:get).with(stage_uri, nil, stage_headers)
-      expect(subject.stage)
-    end
-  end
-
-  context '(private methods)' do
-    describe '#build_request_uri' do
-      context 'for "stage" endpoint' do
-        it 'returns the API uri to initiate a stage request' do
-          expect(subject.send(:build_request_uri, :stage)).to eq "#{subject.config[:api_root]}/stage?external_uri=#{CGI.escape(external_uri)}"
-        end
-      end
-
-      context 'for "status" endpoint' do
-        it 'returns the API uri to initiate a status request' do
-          expect(subject.send(:build_request_uri, :status)).to eq "#{subject.config[:api_root]}/status?external_uri=#{CGI.escape(external_uri)}"
-        end
-      end
-    end
-
-    describe '#build_request_headers' do
-      it 'has a field for "service"' do
-        expect(subject.send(:build_request_headers)).to have_key :service
-      end
-
-      it 'has a field for "events" when we tell it to' do
-        expect(subject.send(:build_request_headers, include_events: true)).to have_key :events
-      end
+  describe '#stage' do
+    let(:service) { "fake_service" }
+    let(:include_events) { true }
+    let(:external_uri) { "fake_uri" }
+    it 'calls #send_request with http_method: :post, action: "stage", passes :inclue_events and :service as headers, and :external_uri as a param' do
+      expect(subject).to receive(:send_request).with(:post, action: "stage", headers: { service: service }, params: { external_uri: external_uri } )
+      subject.stage(service: service, external_uri: external_uri)
     end
   end
 end

--- a/spec/storage_proxy_client/response_spec.rb
+++ b/spec/storage_proxy_client/response_spec.rb
@@ -1,16 +1,12 @@
 require 'spec_helper'
-require 'storage_proxy_client/client'
 
 describe StorageProxyClient::Response do
 
-  let(:mock_faraday_response) do
-    Faraday::Response.new(body: mock_response_body.to_json)
-  end
+  let(:body) { { foo: "bar"}.to_json }
 
-  let(:mock_external_uri) { 'http://pretendvendor.org/123355' }
-  let(:mock_vendor_service) { 'Pretend Vendor' }
+  context 'when the body is a JSON string'
 
-  subject { described_class.new(faraday_response: mock_faraday_response) }
+  subject { described_class.new(body: body) }
 
   describe 'staged?' do
     context 'when the response reports that the file is staged' do

--- a/spec/storage_proxy_client_spec.rb
+++ b/spec/storage_proxy_client_spec.rb
@@ -1,7 +1,0 @@
-require "spec_helper"
-
-RSpec.describe StorageProxyClient do
-  it "has a version number" do
-    expect(StorageProxyClient::VERSION).not_to be nil
-  end
-end

--- a/storage_proxy_api.gemspec
+++ b/storage_proxy_api.gemspec
@@ -1,11 +1,11 @@
 # coding: utf-8
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'storage_proxy_client/version'
+require 'storage_proxy_api/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "storage_proxy_client"
-  spec.version       = StorageProxyClient::VERSION
+  spec.name          = "storage_proxy_api"
+  spec.version       = StorageProxyAPI::VERSION
   spec.authors       = ["Andrew Myers"]
   spec.email         = ["afredmyers@gmail.com"]
 


### PR DESCRIPTION
* Makes it easier to implement new methods to respond to External Storage Proxy API as it develops.
* Goes back to the idea that there is one Client object, with which you can make many API calls.
  - this means that params for the Client constructor are per connection, wheras
  - parameters for identifying files are requred as part of API calls (instead of stored as instance vars).